### PR TITLE
[FEAT] Add udev, fastrtps rmw, and domain bridge

### DIFF
--- a/.bashrc
+++ b/.bashrc
@@ -154,3 +154,4 @@ alias l="ls -lash"
 alias r="source /workspaces/rebuild_colcon.rc"
 alias b="ros2 launch rosbridge_server rosbridge_websocket_launch.xml"
 alias m="make -j"
+alias diff=colordiff

--- a/.github/workflows/docker_publish_ghcr.yaml
+++ b/.github/workflows/docker_publish_ghcr.yaml
@@ -48,7 +48,7 @@ jobs:
       # Add support for more platforms with QEMU (optional)
       # https://github.com/docker/setup-qemu-action
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v3.6.0
 
       # Set up BuildKit Docker container builder to be able to build
       # multi-platform images and export cache

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,13 +29,18 @@ RUN mkdir -p ${ROS2_WS}/src && \
 
     # Necessary System Package Installation
 RUN apt install -y \
+        aspell \
         axel \
         bash-completion \
         bat \
         bmon \
         build-essential \
+        clang-format \
+        colordiff \
+        cppcheck \
         curl \
         git \
+        htop \
         libncurses5-dev \
         libncursesw5-dev \
         lsof \

--- a/Dockerfile
+++ b/Dockerfile
@@ -54,6 +54,7 @@ RUN apt install -y \
         tig \
         tmux \
         tree \
+        udev \
         vim \
         wget
 
@@ -69,7 +70,10 @@ RUN pip3 install --no-cache-dir --upgrade pip && \
 
     # Use our pre-defined bashrc
     mv /tmp/.bashrc /root && \
-    ln -s /root/.bashrc /.bashrc
+    ln -s /root/.bashrc /.bashrc && \
+
+    # Enable udev daemon
+    /lib/systemd/systemd-udevd --daemon || true
 
     ##### ROS2 Installation #####
     # install ros2

--- a/Dockerfile
+++ b/Dockerfile
@@ -88,7 +88,9 @@ RUN apt install -y \
         ccache \
         ros-${ROS_DISTRO}-fastrtps \
         ros-${ROS_DISTRO}-rmw-fastrtps-cpp \
-        ros-${ROS_DISTRO}-rmw-fastrtps-dynamic-cpp
+        ros-${ROS_DISTRO}-rmw-fastrtps-dynamic-cpp \
+        # install domain bridge
+        ros-$ROS_DISTRO-domain-bridge
 
     # install boost serial and json
 RUN apt install -y \

--- a/Dockerfile
+++ b/Dockerfile
@@ -84,7 +84,11 @@ RUN apt install -y \
         python3-vcstool \
         ros-${ROS_DISTRO}-ros-base \
         # install ros bridge
-        ros-${ROS_DISTRO}-rosbridge-suite ccache
+        ros-${ROS_DISTRO}-rosbridge-suite \
+        ccache \
+        ros-${ROS_DISTRO}-fastrtps \
+        ros-${ROS_DISTRO}-rmw-fastrtps-cpp \
+        ros-${ROS_DISTRO}-rmw-fastrtps-dynamic-cpp
 
     # install boost serial and json
 RUN apt install -y \

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,6 +44,7 @@ RUN apt install -y \
         nvtop \
         python3-pip \
         python3-venv \
+        python3-dev \
         screen \
         tig \
         tmux \


### PR DESCRIPTION
We cannot directly mount USB devices to Docker containers on macOS.
Instead, we use a USB over IP (USB/IP) client-server system. With
the server running on macOS, the client inside the Docker engine/VM
can connect to it, allowing the entire Docker engine/VM to create
`/dev/ttyUSB*` devices. Since this setup operates at the VM level,
all containers running on this engine share the same devices.
However, macOS does not allow assigning specific bus IDs, so device
names may change upon restart, replugging, etc. To address this, we
need the base image to install the udev daemon, which dynamically
assigns device names at runtime.

This FastRTPS ROS Middleware library is used to write the ROS bridge
server and client in C++.